### PR TITLE
Changing the line that checks if an object is type GPIO to isinstance

### DIFF
--- a/teachable.py
+++ b/teachable.py
@@ -182,7 +182,7 @@ class UI_EdgeTpuDevBoard(UI):
 
   def setLED(self, index, state):
     """Abstracts away mix of GPIO and PWM LEDs."""
-    if type(self._LEDs[index]) is GPIO: self._LEDs[index].write(not state)
+    if isinstance(self._LEDs[index], GPIO): self._LEDs[index].write(not state)
     else: self._LEDs[index].duty_cycle = 0.0 if state else 1.0
 
   def getButtonState(self):


### PR DESCRIPTION
For the Coral Dev Board, when the GPIO pins are initially configured as inputs/outputs, for each GPIO pin a GPIO object is put into the LED or button array. Later, the function setLED that checks if a pin is a GPIO or PWM object. Originally this is doing using type, but this fix uses isinstance.

For each GPIO object, its actual type is SysfsGPIO based on how it was instantiated ([see periphery docs](https://python-periphery.readthedocs.io/en/latest/gpio.html#periphery.periphery.GPIO.SysfsGPIO)). This means `type(x) is GPIO` will return false while `isinstance(x, GPIO)` will return true since SysfsGPIO is an instance of GPIO but its actual type is SysfsGPIO. Without the fix, setLED would see all pins as PWM, since `type(self._LEDs[index]) is GPIO` would always be false.

Tested: [Step 6: Test the button and LED wiring](https://coral.ai/projects/teachable-machine/#step-6-test-the-button-and-led-wiring) behaves as expected. When a colored button is pressed, the corresponding LED will light up and the console displays which button is pressed.